### PR TITLE
container/env definition and allow GStrings

### DIFF
--- a/functions/validate_schema_params.nf
+++ b/functions/validate_schema_params.nf
@@ -125,7 +125,7 @@ def ValidateParams(){
         }                                  
 
         if(schema_type=="string"){
-            if(schema_value !instanceof String){
+            if((schema_value !instanceof String) && (schema_value !instanceof GString)){
                 ErrorMessenger(value_type_match_error, "=> You provided: $schema_value")
                 schema_error += 1
                 return

--- a/modules/sam_to_bam.nf
+++ b/modules/sam_to_bam.nf
@@ -5,6 +5,10 @@ process Sam2Bam {
     memory params.memory
     publishDir params.publishdir, mode: params.publishmode
 
+    if(workflow.profile.contains('conda'))  { conda "$params.environment" }
+    if(workflow.profile.contains('docker')) { container "$params.container" }
+    if(workflow.profile.contains('singularity')) { container "$params.container" }
+
     input:
     tuple val(sample_id), path(sam)
         

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,37 +1,17 @@
 
-// these two params are necessary in the config so the profiles for conda and docker/singularity work properly
-params.container   = "atpoint/nf_blank:v1.0"
-params.environment = "$baseDir/environment.yml"
-
 profiles {
     
-    local {
-        docker.enabled          = false
-        singularity.enabled     = false
-        conda.enabled           = false
-    }
-
     docker {
-        process.container       = params.container
-        docker.enabled          = true        
+        docker.enabled = true        
     }
 
     singularity {
-        process.container       = "docker://${params.container}"
-        singularity.enabled     = true
-        singularity.autoMounts  = true
+        singularity.enabled = true
+        singularity.autoMounts = true
     }
 
     conda {
-        process.conda           = params.environment
-        conda.enabled           = true
-    }
-
-    // example when using the SLURM scheduler, assuming a queue named "normal" and a runtime of 2h 
-    slurm {
-        process.executor        = 'slurm'
-        process.queue           = 'normal'
-        process.clusterOptions  = '--time=02:00:00'
+        conda.enabled = true
     }
 
 }

--- a/schema.nf
+++ b/schema.nf
@@ -20,7 +20,7 @@ schema.publishmode = [value: 'rellink', type: 'string', mandatory: true, allowed
 
 // env/docker params:
 schema.container = [value:'atpoint/nf_blank:v1.0', type:'string', mandatory:true, allowed:'']
-schema.environment = [value:'$baseDir/environment.yml', type:'string', mandatory:'true', allowed:'']
+schema.environment = [value: "$baseDir/environment.yml", type:'string', mandatory:'true', allowed:'']
 
 // --------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
- move container/environment definitions to the modules (formerly in nextflow.config)
- allow String and GString for `value: 'string'` in schema validation